### PR TITLE
fix coloring of multi-line messages

### DIFF
--- a/logutils/colorize.py
+++ b/logutils/colorize.py
@@ -203,9 +203,12 @@ class ColorizingStreamHandler(logging.StreamHandler):
         """
         message = logging.StreamHandler.format(self, record)
         if self.is_tty:
-            # Don't colorize any traceback
-            parts = message.split('\n', 1)
-            parts[0] = self.colorize(parts[0], record)
-            message = '\n'.join(parts)
+            if record.levelno == logging.ERROR:
+                # Don't colorize any traceback
+                parts = message.split('\nTraceback', 1)
+                parts[0] = self.colorize(parts[0], record)
+                return '\nTraceback'.join(parts)
+            else:
+                return self.colorize(message, record)
         return message
 


### PR DESCRIPTION
The code intended for not-coloring tracebacks did prevent coloring of all but the first line. Therefore, only the first line of any multi-line message was colored.

The fix improves the traceback detection by limiting to loglevel ERROR and stopping colorizing only when a (non-first) line starts with "Traceback". As a result, all other multi-line messages are colored completely.
